### PR TITLE
Fix: prevent CDN caching of authenticated routes

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,6 +2,8 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import LoginPageClient from "./LoginPageClient";
 
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: "Login - Aidan Kirvan",
   description: "Login page"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,26 @@
 import { auth } from '@/auth';
+import { NextResponse } from 'next/server';
 
-export default auth;
+export default auth((req) => {
+  const response = NextResponse.next();
+
+  // Set no-cache headers for admin, auth, and login routes
+  // This ensures Netlify CDN doesn't cache authenticated pages
+  if (
+    req.nextUrl.pathname.startsWith('/admin') ||
+    req.nextUrl.pathname.startsWith('/api/auth') ||
+    req.nextUrl.pathname === '/login'
+  ) {
+    response.headers.set(
+      'Cache-Control',
+      'no-store, no-cache, must-revalidate, proxy-revalidate'
+    );
+    response.headers.set('Pragma', 'no-cache');
+    response.headers.set('Expires', '0');
+  }
+
+  return response;
+});
 
 export const config = {
   // Match all paths except:


### PR DESCRIPTION
Set explicit Cache-Control headers in middleware for /admin, /api/auth, and /login routes to ensure Netlify CDN doesn't cache authenticated pages. This fixes signout not working on production deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)